### PR TITLE
vendor: perf: sepolicy: Address qcom perf hal denials

### DIFF
--- a/vendor/perf/qti-perf.mk
+++ b/vendor/perf/qti-perf.mk
@@ -70,5 +70,8 @@ PRODUCT_VENDOR_PROPERTIES += vendor.pasr.activemode.enabled=true
 endif
 endif
 
+# Sepolicy
+BOARD_VENDOR_SEPOLICY_DIRS += $(QCOM_COMMON_PATH)/vendor/perf/sepolicy/
+
 # Get non-open-source specific aspects
 $(call inherit-product-if-exists, vendor/qcom/common/vendor/perf/perf-vendor.mk)

--- a/vendor/perf/sepolicy/hal_perf_default.te
+++ b/vendor/perf/sepolicy/hal_perf_default.te
@@ -1,0 +1,1 @@
+r_dir_file(vendor_hal_perf_default, system_server)


### PR DESCRIPTION
Example:

[  128.095008] type=1400 audit(1645817709.841:298): avc: denied { search } for comm=41646170744C61756E636820566D name="2000" dev="proc" ino=115588 scontext=u:r:vendor_hal_perf_default:s0 tcontext=u:r:system_server:s0 tclass=dir permissive=0

Signed-off-by: chrisl7 <wandersonrodriguesf1@gmail.com>
Change-Id: Id9db7d987098f0c8fc2d964d07f8e86df09f8dff